### PR TITLE
Update workflow and versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG=${{ steps.version.outputs.version }}
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release delete "$TAG" -y
-            gh api -X DELETE "repos/${{ github.repository }}/git/refs/tags/$TAG"
+          if state=$(gh release view "$TAG" --json draft -q .draft 2>/dev/null); then
+            if [ "$state" = "false" ]; then
+              gh release delete "$TAG" -y
+              gh api -X DELETE "repos/${{ github.repository }}/git/refs/tags/$TAG"
+            fi
           fi
       - name: Build
         run: mvn -B -f RandomDrop/pom.xml package
@@ -47,12 +49,13 @@ jobs:
           mv RandomDrop/target/osef.jar "$NAME"
           echo "file=$NAME" >> "$GITHUB_OUTPUT"
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: RandomDrop ${{ steps.version.outputs.version }}
           files: ${{ steps.prepare.outputs.file }}
-          prerelease: ${{ github.ref == 'refs/heads/dev' }}
-          generate_release_notes: true
+          draft: ${{ github.ref == 'refs/heads/dev' }}
+          prerelease: false
+          generate_release_notes: ${{ github.ref != 'refs/heads/dev' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # RandomDrop
 
-RandomDrop is a Minecraft plugin that replaces every drop with a deterministic random item. The project targets **Paper 1.21.6** and is intended to be dropped straight into your server's `plugins` folder.
+RandomDrop is a Minecraft plugin that replaces every drop with a deterministic random item. The project targets **Paper 1.21.7** and is intended to be dropped straight into your server's `plugins` folder.
 
 ## Building from source
 

--- a/RandomDrop/pom.xml
+++ b/RandomDrop/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.theo546</groupId>
     <artifactId>RandomDrop</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <name>RandomDrop</name>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.6-R0.1-SNAPSHOT</version>
+            <version>1.21.7-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/RandomDrop/src/main/resources/plugin.yml
+++ b/RandomDrop/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: com.theo546.randomdrop.Main
 name: RandomDrop
-version: "1.1.0"
+version: "1.1.1"
 api-version: 1.21
 author: theo546
 description: A Paper plugin to randomize the Minecraft loot table!


### PR DESCRIPTION
## Summary
- avoid deleting draft releases
- switch release action to `softprops/action-gh-release@v2`
- produce draft releases for dev branch and skip release notes
- bump plugin version to 1.1.1 and target Paper 1.21.7

## Testing
- `mvn -B -f RandomDrop/pom.xml package`


------
https://chatgpt.com/codex/tasks/task_b_6862a8a0905c832d910ec9ffe927f8b5